### PR TITLE
Fix missing `.sh` file extension for running some scripts

### DIFF
--- a/linien/gui/ui/device_manager.py
+++ b/linien/gui/ui/device_manager.py
@@ -138,7 +138,7 @@ class DeviceManager(QtWidgets.QMainWindow, CustomWidget):
                         A production version is installed on the RedPitaya, 
                         but the client uses a development version. Stop the 
                         server and uninstall the version on the RedPitaya using\n
-                        linien_stop_server;\n
+                        linien_stop_server.sh;\n
                         pip3 uninstall linien-server\n
                         before trying it again.
                         """  # noqa: W291

--- a/linien/gui/ui/device_manager.py
+++ b/linien/gui/ui/device_manager.py
@@ -216,7 +216,7 @@ class DeviceManager(QtWidgets.QMainWindow, CustomWidget):
         if version is not None:
             version_string = "==" + version
             # stop server if another version of linien is installed
-            stop_server_command = "linien_stop_server;"
+            stop_server_command = "linien_stop_server.sh;"
 
         self.ssh_command = execute_command_and_show_output(
             self,

--- a/linien/server/linien_start_server.sh
+++ b/linien/server/linien_start_server.sh
@@ -8,7 +8,7 @@
 pth=`python3 -c 'import linien; print(linien.__path__[0]);'`
 
 # quit any remaining screen session
-if [ -x "$(command -v linien_stop_server)" ]; then
+if [ -x "$(command -v linien_stop_server.sh)" ]; then
     linien_stop_server
 fi
 screen -X -S linien-server quit

--- a/linien/server/linien_stop_server.sh
+++ b/linien/server/linien_stop_server.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 screen -X -S linien-server quit
-bash linien_start_ethernet_blinking
+bash linien_start_ethernet_blinking.sh


### PR DESCRIPTION
This prevented the server being shut down properly and ethernet blinking being started and stopped.