### PR TITLE
Simplify the app structure

### DIFF
--- a/linien-gui/linien_gui/app.py
+++ b/linien-gui/linien_gui/app.py
@@ -92,11 +92,6 @@ class QTApp(QtCore.QObject):
 
             QtCore.QTimer.singleShot(50, self.call_listeners)
 
-    def get_widget(self, name, window=None):
-        """Queries a widget by name."""
-        window = window or self.main_window
-        return window.findChild(QtCore.QObject, name)
-
     def close(self):
         self.app.quit()
 

--- a/linien-gui/linien_gui/app.py
+++ b/linien-gui/linien_gui/app.py
@@ -28,12 +28,15 @@ from linien_gui.ui.version_checker import VersionCheckerThread
 from linien_gui.utils import set_window_icon
 from linien_gui.widgets import UI_PATH, CustomWidget
 from PyQt5 import QtWidgets
+from PyQt5.QtCore import pyqtSignal
 from pyqtgraph.Qt import QtCore
 
 sys.path += [str(UI_PATH)]
 
 
 class QTApp(QtCore.QObject):
+    connection_established = pyqtSignal()
+
     def __init__(self):
         self.app = QtWidgets.QApplication(sys.argv)
 
@@ -60,14 +63,16 @@ class QTApp(QtCore.QObject):
         self.control = client.control
         self.parameters = client.parameters
 
+        self.connection_established.emit()
+
         for instance in CustomWidget.instances:
             try:
                 instance.on_connection_established()
             except Exception:
                 print(
                     (
-                        "The error below happend when calling connection_established "
-                        "of a widget. This may happen if the widget was recently "
+                        "The error below happend when calling on_connection_established"
+                        " of a widget. This may happen if the widget was recently "
                         "destroyed."
                     )
                 )

--- a/linien-gui/linien_gui/ui/device_manager.py
+++ b/linien-gui/linien_gui/ui/device_manager.py
@@ -28,14 +28,14 @@ from linien_gui.dialogs import (
 from linien_gui.threads import ConnectionThread
 from linien_gui.ui.new_device_dialog import NewDeviceDialog
 from linien_gui.utils import set_window_icon
-from linien_gui.widgets import CustomWidget
-from PyQt5 import QtCore, QtWidgets
+from linien_gui.widgets import UI_PATH, CustomWidget
+from PyQt5 import QtCore, QtWidgets, uic
 
 
 class DeviceManager(QtWidgets.QMainWindow, CustomWidget):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.load_ui("device_manager.ui")
+        uic.loadUi(UI_PATH / "device_manager.ui", self)
         self.setWindowTitle(f"Linien spectroscopy lock v{linien_gui.__version__}")
         set_window_icon(self)
 

--- a/linien-gui/linien_gui/ui/general_panel.py
+++ b/linien-gui/linien_gui/ui/general_panel.py
@@ -25,14 +25,14 @@ from linien_common.common import (
     convert_channel_mixing_value,
 )
 from linien_gui.utils import param2ui
-from linien_gui.widgets import CustomWidget
-from PyQt5 import QtWidgets
+from linien_gui.widgets import UI_PATH, CustomWidget
+from PyQt5 import QtWidgets, uic
 
 
 class GeneralPanel(QtWidgets.QWidget, CustomWidget):
     def __init__(self, *args, **kwargs):
         super(GeneralPanel, self).__init__(*args, **kwargs)
-        self.load_ui("general_panel.ui")
+        uic.loadUi(UI_PATH / "general_panel.ui", self)
 
         self.channelMixingSlider.valueChanged.connect(self.on_channel_mixing_changed)
         self.fastModeCheckBox.stateChanged.connect(self.on_fast_mode_changed)

--- a/linien-gui/linien_gui/ui/locking_panel.py
+++ b/linien-gui/linien_gui/ui/locking_panel.py
@@ -18,14 +18,14 @@
 
 from linien_common.common import FAST_AUTOLOCK
 from linien_gui.utils import param2ui
-from linien_gui.widgets import CustomWidget
-from PyQt5 import QtWidgets
+from linien_gui.widgets import UI_PATH, CustomWidget
+from PyQt5 import QtWidgets, uic
 
 
 class LockingPanel(QtWidgets.QWidget, CustomWidget):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.load_ui("locking_panel.ui")
+        uic.loadUi(UI_PATH / "locking_panel.ui", self)
 
     def ready(self):
         self.ids.kp.valueChanged.connect(self.kp_changed)

--- a/linien-gui/linien_gui/ui/main_window.py
+++ b/linien-gui/linien_gui/ui/main_window.py
@@ -161,7 +161,7 @@ class MainWindow(QtWidgets.QMainWindow, CustomWidget):
             optimization = self.parameters.optimization_running.value
             locked = self.parameters.lock.value
 
-            self.get_widget("sweep_control").setVisible(
+            self.get_widget("sweepControlWidget").setVisible(
                 not al_running and not locked and not optimization
             )
             self.get_widget("top_lock_panel").setVisible(locked)

--- a/linien-gui/linien_gui/ui/main_window.py
+++ b/linien-gui/linien_gui/ui/main_window.py
@@ -49,8 +49,7 @@ class MainWindow(QtWidgets.QMainWindow, CustomWidget):
 
     def show(self, host, name):
         self.setWindowTitle(
-            "Linien spectroscopy lock %s: %s (%s)"
-            % (linien_gui.__version__, name, host)
+            f"Linien spectroscopy lock {linien_gui.__version__}: {name} ({host})"
         )
         super().show()
 
@@ -126,13 +125,11 @@ class MainWindow(QtWidgets.QMainWindow, CustomWidget):
 
     def import_parameters(self):
         options = QtWidgets.QFileDialog.Options()
-        # options |= QtWidgets.QFileDialog.DontUseNativeDialog
-        default_ext = ".json"
         fn, _ = QtWidgets.QFileDialog.getOpenFileName(
             self,
             "QFileDialog.getSaveFileName()",
             "",
-            "JSON (*%s)" % default_ext,
+            "JSON (*.json)",
             options=options,
         )
         if fn:

--- a/linien-gui/linien_gui/ui/main_window.py
+++ b/linien-gui/linien_gui/ui/main_window.py
@@ -28,8 +28,8 @@ from linien_common.config import N_COLORS
 from linien_gui.config import Color
 from linien_gui.ui.plot_widget import INVALID_POWER
 from linien_gui.utils import color_to_hex
-from linien_gui.widgets import CustomWidget
-from PyQt5 import QtWidgets
+from linien_gui.widgets import UI_PATH, CustomWidget
+from PyQt5 import QtWidgets, uic
 
 ZOOM_STEP = 0.9
 MAX_ZOOM = 50
@@ -43,7 +43,7 @@ def sweep_amplitude_to_zoom_step(amplitude):
 class MainWindow(QtWidgets.QMainWindow, CustomWidget):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.load_ui("main_window.ui")
+        uic.loadUi(UI_PATH / "main_window.ui", self)
 
         self.reset_std_history()
 

--- a/linien-gui/linien_gui/ui/main_window.ui
+++ b/linien-gui/linien_gui/ui/main_window.ui
@@ -33,10 +33,10 @@
        <item>
         <layout class="QVBoxLayout" name="verticalLayout_17">
          <item>
-          <widget class="SweepControlWidget" name="sweep_control" native="true">
+          <widget class="SweepControlWidget" name="sweepControlWidget" native="true">
            <layout class="QHBoxLayout" name="horizontalLayout_3">
             <item>
-             <widget class="QLabel" name="label_9">
+             <widget class="QLabel" name="sweepLabel">
               <property name="font">
                <font>
                 <weight>75</weight>
@@ -49,7 +49,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QPushButton" name="sweep_start_stop_button">
+             <widget class="QPushButton" name="sweepStartStopPushButton">
               <property name="toolTip">
                <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
@@ -79,7 +79,7 @@ p, li { white-space: pre-wrap; }
              </spacer>
             </item>
             <item>
-             <widget class="SweepSlider" name="sweep_slider">
+             <widget class="SweepSlider" name="sweepSlider">
               <property name="minimumSize">
                <size>
                 <width>350</width>
@@ -108,7 +108,7 @@ p, li { white-space: pre-wrap; }
              </spacer>
             </item>
             <item>
-             <widget class="QLabel" name="label_2">
+             <widget class="QLabel" name="sweepCenterLabel">
               <property name="font">
                <font>
                 <weight>75</weight>
@@ -121,7 +121,7 @@ p, li { white-space: pre-wrap; }
              </widget>
             </item>
             <item>
-             <widget class="CustomDoubleSpinBox" name="sweep_center">
+             <widget class="CustomDoubleSpinBox" name="sweepCenterSpinBox">
               <property name="minimumSize">
                <size>
                 <width>65</width>
@@ -159,7 +159,7 @@ p, li { white-space: pre-wrap; }
              </widget>
             </item>
             <item>
-             <widget class="QLabel" name="label_3">
+             <widget class="QLabel" name="sweepAmplitudeLabel">
               <property name="font">
                <font>
                 <weight>75</weight>
@@ -172,7 +172,7 @@ p, li { white-space: pre-wrap; }
              </widget>
             </item>
             <item>
-             <widget class="CustomDoubleSpinBox" name="sweep_amplitude">
+             <widget class="CustomDoubleSpinBox" name="sweepAmplitudeSpinBox">
               <property name="minimumSize">
                <size>
                 <width>65</width>
@@ -1054,8 +1054,8 @@ p, li { white-space: pre-wrap; }
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>98</width>
-            <height>28</height>
+            <width>338</width>
+            <height>510</height>
            </rect>
           </property>
           <attribute name="label">
@@ -1072,8 +1072,8 @@ p, li { white-space: pre-wrap; }
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>98</width>
-            <height>28</height>
+            <width>338</width>
+            <height>510</height>
            </rect>
           </property>
           <attribute name="label">
@@ -1090,8 +1090,8 @@ p, li { white-space: pre-wrap; }
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>332</width>
-            <height>427</height>
+            <width>338</width>
+            <height>510</height>
            </rect>
           </property>
           <attribute name="label">
@@ -1108,8 +1108,8 @@ p, li { white-space: pre-wrap; }
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>98</width>
-            <height>28</height>
+            <width>338</width>
+            <height>510</height>
            </rect>
           </property>
           <property name="sizePolicy">
@@ -1132,8 +1132,8 @@ p, li { white-space: pre-wrap; }
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>98</width>
-            <height>28</height>
+            <width>338</width>
+            <height>510</height>
            </rect>
           </property>
           <property name="sizePolicy">

--- a/linien-gui/linien_gui/ui/modulation_sweep_panel.py
+++ b/linien-gui/linien_gui/ui/modulation_sweep_panel.py
@@ -18,14 +18,14 @@
 
 from linien_common.common import MHz, Vpp
 from linien_gui.utils import param2ui
-from linien_gui.widgets import CustomWidget
-from PyQt5 import QtWidgets
+from linien_gui.widgets import UI_PATH, CustomWidget
+from PyQt5 import QtWidgets, uic
 
 
 class ModulationAndSweepPanel(QtWidgets.QWidget, CustomWidget):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.load_ui("modulation_sweep_panel.ui")
+        uic.loadUi(UI_PATH / "modulation_sweep_panel.ui", self)
 
     def ready(self):
         self.ids.modulation_frequency.setKeyboardTracking(False)

--- a/linien-gui/linien_gui/ui/new_device_dialog.py
+++ b/linien-gui/linien_gui/ui/new_device_dialog.py
@@ -20,14 +20,14 @@ import string
 
 from linien_common.config import DEFAULT_SERVER_PORT
 from linien_gui.config import load_device_data, save_device_data
-from linien_gui.widgets import CustomWidget
-from PyQt5 import QtWidgets
+from linien_gui.widgets import UI_PATH, CustomWidget
+from PyQt5 import QtWidgets, uic
 
 
 class NewDeviceDialog(QtWidgets.QDialog, CustomWidget):
     def __init__(self, initial_device=None):
         super().__init__()
-        self.load_ui("new_device_dialog.ui")
+        uic.loadUi(UI_PATH / "new_device_dialog.ui", self)
 
         if initial_device is not None:
             self.ids.deviceName.setText(initial_device["name"])

--- a/linien-gui/linien_gui/ui/optimization_panel.py
+++ b/linien-gui/linien_gui/ui/optimization_panel.py
@@ -18,14 +18,14 @@
 
 from linien_common.common import MHz, Vpp
 from linien_gui.utils import param2ui
-from linien_gui.widgets import CustomWidget
-from PyQt5 import QtWidgets
+from linien_gui.widgets import UI_PATH, CustomWidget
+from PyQt5 import QtWidgets, uic
 
 
 class OptimizationPanel(QtWidgets.QWidget, CustomWidget):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.load_ui("optimization_panel.ui")
+        uic.loadUi(UI_PATH / "optimization_panel.ui", self)
 
     def ready(self):
         self.ids.start_optimization_btn.clicked.connect(self.start_optimization)

--- a/linien-gui/linien_gui/ui/psd_window.py
+++ b/linien-gui/linien_gui/ui/psd_window.py
@@ -23,14 +23,14 @@ import linien_gui
 from linien_common.common import PSD_ALGORITHM_LPSD, PSD_ALGORITHM_WELCH
 from linien_gui.dialogs import error_dialog
 from linien_gui.utils import RandomColorChoser, param2ui, set_window_icon
-from linien_gui.widgets import CustomWidget
-from PyQt5 import QtWidgets
+from linien_gui.widgets import UI_PATH, CustomWidget
+from PyQt5 import QtWidgets, uic
 
 
 class PSDWindow(QtWidgets.QMainWindow, CustomWidget):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.load_ui("psd_window.ui")
+        uic.loadUi(UI_PATH / "psd_window.ui", self)
         self.setWindowTitle("Linien: Noise analysis")
         set_window_icon(self)
         self.random_color_choser = RandomColorChoser()

--- a/linien-gui/linien_gui/ui/spectroscopy_panel.py
+++ b/linien-gui/linien_gui/ui/spectroscopy_panel.py
@@ -18,14 +18,14 @@
 
 from linien_common.common import HIGH_PASS_FILTER, LOW_PASS_FILTER
 from linien_gui.utils import param2ui
-from linien_gui.widgets import CustomWidget
-from PyQt5 import QtWidgets
+from linien_gui.widgets import UI_PATH, CustomWidget
+from PyQt5 import QtWidgets, uic
 
 
 class SpectroscopyPanel(QtWidgets.QWidget, CustomWidget):
     def __init__(self, *args):
         super().__init__(*args)
-        self.load_ui("spectroscopy_panel.ui")
+        uic.loadUi(UI_PATH / "spectroscopy_panel.ui", self)
 
         def change_filter_frequency(filter_i):
             self.get_param("filter_%d_frequency" % filter_i).value = getattr(

--- a/linien-gui/linien_gui/ui/sweep_control.py
+++ b/linien-gui/linien_gui/ui/sweep_control.py
@@ -17,16 +17,20 @@
 
 import superqt
 from linien_gui.widgets import CustomWidget
-from PyQt5 import QtWidgets
+from PyQt5 import QtCore, QtWidgets
 
 
-class SweepControlWidget(QtWidgets.QWidget, CustomWidget):
+class SweepControlWidget(QtWidgets.QWidget):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        QtCore.QTimer.singleShot(100, self.ready)
 
     def ready(self):
         # initialize sweep slider boundaries
+        self.app = self.window()._app
+        self.ids = self.app.main_window
         self.ids.sweepSlider.init()
+        self.app.connection_established.connect(self.on_connection_established)
 
     def on_connection_established(self):
         self.control = self.app.control

--- a/linien-gui/linien_gui/ui/sweep_control.py
+++ b/linien-gui/linien_gui/ui/sweep_control.py
@@ -26,19 +26,19 @@ class SweepControlWidget(QtWidgets.QWidget, CustomWidget):
 
     def ready(self):
         # initialize sweep slider boundaries
-        self.ids.sweep_slider.init()
+        self.ids.sweepSlider.init()
 
     def on_connection_established(self):
         self.control = self.app.control
         self.parameters = self.app.parameters
 
-        self.ids.sweep_slider.valueChanged.connect(self.update_sweep_range)
+        self.ids.sweepSlider.valueChanged.connect(self.update_sweep_range)
         # NOTE: The keyboardTracking property of the QDoubleSpinBoxes has been set to
         # False, to avoid signal emission when editing the field. Signals are still
         # emitted when using the arrow buttons. See also the editingFinished method.
-        self.ids.sweep_center.valueChanged.connect(self.update_sweep_center)
-        self.ids.sweep_amplitude.valueChanged.connect(self.update_sweep_amplitude)
-        self.ids.sweep_start_stop_button.clicked.connect(self.pause_or_resume_sweep)
+        self.ids.sweepCenterSpinBox.valueChanged.connect(self.update_sweep_center)
+        self.ids.sweepAmplitudeSpinBox.valueChanged.connect(self.update_sweep_amplitude)
+        self.ids.sweepStartStopPushButton.clicked.connect(self.pause_or_resume_sweep)
 
         # initialize sweep controls
         self.display_sweep_status()
@@ -56,21 +56,21 @@ class SweepControlWidget(QtWidgets.QWidget, CustomWidget):
 
         # block signals to avoid infinite loops when changing sweep parameters, see also
         # param2ui
-        self.ids.sweep_slider.blockSignals(True)
-        self.ids.sweep_amplitude.blockSignals(True)
-        self.ids.sweep_center.blockSignals(True)
+        self.ids.sweepSlider.blockSignals(True)
+        self.ids.sweepAmplitudeSpinBox.blockSignals(True)
+        self.ids.sweepCenterSpinBox.blockSignals(True)
 
-        self.ids.sweep_slider.setValue((min_, max_))
-        self.ids.sweep_center.setValue(center)
-        self.ids.sweep_amplitude.setValue(amplitude)
+        self.ids.sweepSlider.setValue((min_, max_))
+        self.ids.sweepCenterSpinBox.setValue(center)
+        self.ids.sweepAmplitudeSpinBox.setValue(amplitude)
         if self.parameters.sweep_pause.value:
-            self.ids.sweep_start_stop_button.setText("Start")
+            self.ids.sweepStartStopPushButton.setText("Start")
         else:
-            self.ids.sweep_start_stop_button.setText("Pause")
+            self.ids.sweepStartStopPushButton.setText("Pause")
 
-        self.ids.sweep_slider.blockSignals(False)
-        self.ids.sweep_center.blockSignals(False)
-        self.ids.sweep_amplitude.blockSignals(False)
+        self.ids.sweepSlider.blockSignals(False)
+        self.ids.sweepCenterSpinBox.blockSignals(False)
+        self.ids.sweepAmplitudeSpinBox.blockSignals(False)
 
     def pause_or_resume_sweep(self):
         # If sweep is paused, resume it or vice versa.

--- a/linien-gui/linien_gui/ui/sweep_control.py
+++ b/linien-gui/linien_gui/ui/sweep_control.py
@@ -16,33 +16,39 @@
 # along with Linien.  If not, see <http://www.gnu.org/licenses/>.
 
 import superqt
-from linien_gui.widgets import CustomWidget
 from PyQt5 import QtCore, QtWidgets
 
 
 class SweepControlWidget(QtWidgets.QWidget):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(SweepControlWidget, self).__init__(*args, **kwargs)
         QtCore.QTimer.singleShot(100, self.ready)
 
     def ready(self):
-        # initialize sweep slider boundaries
-        self.app = self.window()._app
-        self.ids = self.app.main_window
-        self.ids.sweepSlider.init()
+        self.main_window = self.window()
+        self.app = self.main_window.app
+        self.main_window = self.app.main_window
         self.app.connection_established.connect(self.on_connection_established)
+
+        self.main_window.sweepSlider.init()  # initialize sweep slider boundaries
 
     def on_connection_established(self):
         self.control = self.app.control
         self.parameters = self.app.parameters
 
-        self.ids.sweepSlider.valueChanged.connect(self.update_sweep_range)
+        self.main_window.sweepSlider.valueChanged.connect(self.update_sweep_range)
         # NOTE: The keyboardTracking property of the QDoubleSpinBoxes has been set to
         # False, to avoid signal emission when editing the field. Signals are still
         # emitted when using the arrow buttons. See also the editingFinished method.
-        self.ids.sweepCenterSpinBox.valueChanged.connect(self.update_sweep_center)
-        self.ids.sweepAmplitudeSpinBox.valueChanged.connect(self.update_sweep_amplitude)
-        self.ids.sweepStartStopPushButton.clicked.connect(self.pause_or_resume_sweep)
+        self.main_window.sweepCenterSpinBox.valueChanged.connect(
+            self.update_sweep_center
+        )
+        self.main_window.sweepAmplitudeSpinBox.valueChanged.connect(
+            self.update_sweep_amplitude
+        )
+        self.main_window.sweepStartStopPushButton.clicked.connect(
+            self.pause_or_resume_sweep
+        )
 
         # initialize sweep controls
         self.display_sweep_status()
@@ -60,21 +66,21 @@ class SweepControlWidget(QtWidgets.QWidget):
 
         # block signals to avoid infinite loops when changing sweep parameters, see also
         # param2ui
-        self.ids.sweepSlider.blockSignals(True)
-        self.ids.sweepAmplitudeSpinBox.blockSignals(True)
-        self.ids.sweepCenterSpinBox.blockSignals(True)
+        self.main_window.sweepSlider.blockSignals(True)
+        self.main_window.sweepAmplitudeSpinBox.blockSignals(True)
+        self.main_window.sweepCenterSpinBox.blockSignals(True)
 
-        self.ids.sweepSlider.setValue((min_, max_))
-        self.ids.sweepCenterSpinBox.setValue(center)
-        self.ids.sweepAmplitudeSpinBox.setValue(amplitude)
+        self.main_window.sweepSlider.setValue((min_, max_))
+        self.main_window.sweepCenterSpinBox.setValue(center)
+        self.main_window.sweepAmplitudeSpinBox.setValue(amplitude)
         if self.parameters.sweep_pause.value:
-            self.ids.sweepStartStopPushButton.setText("Start")
+            self.main_window.sweepStartStopPushButton.setText("Start")
         else:
-            self.ids.sweepStartStopPushButton.setText("Pause")
+            self.main_window.sweepStartStopPushButton.setText("Pause")
 
-        self.ids.sweepSlider.blockSignals(False)
-        self.ids.sweepCenterSpinBox.blockSignals(False)
-        self.ids.sweepAmplitudeSpinBox.blockSignals(False)
+        self.main_window.sweepSlider.blockSignals(False)
+        self.main_window.sweepCenterSpinBox.blockSignals(False)
+        self.main_window.sweepAmplitudeSpinBox.blockSignals(False)
 
     def pause_or_resume_sweep(self):
         # If sweep is paused, resume it or vice versa.
@@ -98,7 +104,7 @@ class SweepControlWidget(QtWidgets.QWidget):
         self.control.write_registers()
 
 
-class SweepSlider(superqt.QDoubleRangeSlider, CustomWidget):
+class SweepSlider(superqt.QDoubleRangeSlider):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/linien-gui/linien_gui/ui/sweep_control.py
+++ b/linien-gui/linien_gui/ui/sweep_control.py
@@ -16,39 +16,33 @@
 # along with Linien.  If not, see <http://www.gnu.org/licenses/>.
 
 import superqt
+from linien_gui.widgets import CustomWidget
 from PyQt5 import QtCore, QtWidgets
 
 
 class SweepControlWidget(QtWidgets.QWidget):
     def __init__(self, *args, **kwargs):
-        super(SweepControlWidget, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         QtCore.QTimer.singleShot(100, self.ready)
 
     def ready(self):
-        self.main_window = self.window()
-        self.app = self.main_window.app
-        self.main_window = self.app.main_window
+        # initialize sweep slider boundaries
+        self.app = self.window()._app
+        self.ids = self.app.main_window
+        self.ids.sweepSlider.init()
         self.app.connection_established.connect(self.on_connection_established)
-
-        self.main_window.sweepSlider.init()  # initialize sweep slider boundaries
 
     def on_connection_established(self):
         self.control = self.app.control
         self.parameters = self.app.parameters
 
-        self.main_window.sweepSlider.valueChanged.connect(self.update_sweep_range)
+        self.ids.sweepSlider.valueChanged.connect(self.update_sweep_range)
         # NOTE: The keyboardTracking property of the QDoubleSpinBoxes has been set to
         # False, to avoid signal emission when editing the field. Signals are still
         # emitted when using the arrow buttons. See also the editingFinished method.
-        self.main_window.sweepCenterSpinBox.valueChanged.connect(
-            self.update_sweep_center
-        )
-        self.main_window.sweepAmplitudeSpinBox.valueChanged.connect(
-            self.update_sweep_amplitude
-        )
-        self.main_window.sweepStartStopPushButton.clicked.connect(
-            self.pause_or_resume_sweep
-        )
+        self.ids.sweepCenterSpinBox.valueChanged.connect(self.update_sweep_center)
+        self.ids.sweepAmplitudeSpinBox.valueChanged.connect(self.update_sweep_amplitude)
+        self.ids.sweepStartStopPushButton.clicked.connect(self.pause_or_resume_sweep)
 
         # initialize sweep controls
         self.display_sweep_status()
@@ -66,21 +60,21 @@ class SweepControlWidget(QtWidgets.QWidget):
 
         # block signals to avoid infinite loops when changing sweep parameters, see also
         # param2ui
-        self.main_window.sweepSlider.blockSignals(True)
-        self.main_window.sweepAmplitudeSpinBox.blockSignals(True)
-        self.main_window.sweepCenterSpinBox.blockSignals(True)
+        self.ids.sweepSlider.blockSignals(True)
+        self.ids.sweepAmplitudeSpinBox.blockSignals(True)
+        self.ids.sweepCenterSpinBox.blockSignals(True)
 
-        self.main_window.sweepSlider.setValue((min_, max_))
-        self.main_window.sweepCenterSpinBox.setValue(center)
-        self.main_window.sweepAmplitudeSpinBox.setValue(amplitude)
+        self.ids.sweepSlider.setValue((min_, max_))
+        self.ids.sweepCenterSpinBox.setValue(center)
+        self.ids.sweepAmplitudeSpinBox.setValue(amplitude)
         if self.parameters.sweep_pause.value:
-            self.main_window.sweepStartStopPushButton.setText("Start")
+            self.ids.sweepStartStopPushButton.setText("Start")
         else:
-            self.main_window.sweepStartStopPushButton.setText("Pause")
+            self.ids.sweepStartStopPushButton.setText("Pause")
 
-        self.main_window.sweepSlider.blockSignals(False)
-        self.main_window.sweepCenterSpinBox.blockSignals(False)
-        self.main_window.sweepAmplitudeSpinBox.blockSignals(False)
+        self.ids.sweepSlider.blockSignals(False)
+        self.ids.sweepCenterSpinBox.blockSignals(False)
+        self.ids.sweepAmplitudeSpinBox.blockSignals(False)
 
     def pause_or_resume_sweep(self):
         # If sweep is paused, resume it or vice versa.
@@ -104,7 +98,7 @@ class SweepControlWidget(QtWidgets.QWidget):
         self.control.write_registers()
 
 
-class SweepSlider(superqt.QDoubleRangeSlider):
+class SweepSlider(superqt.QDoubleRangeSlider, CustomWidget):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/linien-gui/linien_gui/ui/view_panel.py
+++ b/linien-gui/linien_gui/ui/view_panel.py
@@ -23,14 +23,14 @@ from os import path
 import numpy as np
 from linien_common.config import N_COLORS
 from linien_gui.utils import color_to_hex, param2ui
-from linien_gui.widgets import CustomWidget
-from PyQt5 import QtGui, QtWidgets
+from linien_gui.widgets import UI_PATH, CustomWidget
+from PyQt5 import QtGui, QtWidgets, uic
 
 
 class ViewPanel(QtWidgets.QWidget, CustomWidget):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.load_ui("view_panel.ui")
+        uic.loadUi(UI_PATH / "view_panel.ui", self)
 
     def ready(self):
         self.ids.export_select_file.clicked.connect(self.do_export_select_file)

--- a/linien-gui/linien_gui/widgets.py
+++ b/linien-gui/linien_gui/widgets.py
@@ -19,7 +19,6 @@
 import weakref
 from pathlib import Path
 
-from PyQt5 import uic
 from pyqtgraph.Qt import QtCore
 
 UI_PATH = Path(__file__).parents[0].resolve() / "ui"

--- a/linien-gui/linien_gui/widgets.py
+++ b/linien-gui/linien_gui/widgets.py
@@ -66,8 +66,3 @@ class CustomWidget:
     @app.setter
     def app(self, app):
         self._app = app
-
-    def load_ui(self, name):
-        assert name.endswith(".ui")
-        path = UI_PATH / name
-        uic.loadUi(str(path), self)


### PR DESCRIPTION
Want to remove or at least simplify `CustomWidget` and have an QTApp that subclasses simply from `QApplication` rather then the solution used right now.

Also, calling `ready` after some hard-coded time with `singleShot` is not the proper approach.

`on_connection_established` should be triggered with a `pyqtSignal` rather than explicity via calling them in the for-loop over all instances of `CustomWidget`.