### PR TITLE
Release v2.0.3

### DIFF
--- a/linien-client/pyproject.toml
+++ b/linien-client/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "fabric>=2.7.0,<3.0",
+    "fabric>=3.2.2,<4.0",
     "typing_extensions>=4.5.0,<5.0",
     "linien-common==2.0.2",
 ]


### PR DESCRIPTION
Hotfix that bumps version of `fabric` to be compatible with Python 3.12.

Fixes #401.