### PR TITLE
Make importlib-metadata dep upper version constraint higher

### DIFF
--- a/linien-common/pyproject.toml
+++ b/linien-common/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "appdirs>=1.4.4,<2.0",
-    "importlib_metadata>=2.1.3,<5.0",
+    "importlib_metadata>=2.1.3,<9.0",
     "numpy>=1.21.5,<2.0",
     "rpyc>=6.0,<7.0",
     "scipy>=1.8.0,<2.0",


### PR DESCRIPTION
I tested the gui to work successfully with the latest and greatest importlib-metadata 7.1.0. In the context of my flake.nix setup.
