### PR TITLE
server: enable pyrp3 dependency for all platforms

### DIFF
--- a/linien-server/pyproject.toml
+++ b/linien-server/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "fire>=0.6.0",
     "influxdb-client[ciso]>=1.9,<2.0",
     "pylpsd>=0.1.4",
-    "pyrp3>=2.0.1,<3.0;platform_machine=='armv7l'",
+    "pyrp3>=2.0.1,<3.0",
     "linien-common==2.0.4",
 ]
 


### PR DESCRIPTION
No other machines should really use the server, and this dependency doesn't hurt any other platform that is used to test the server. This also helps a bit installing the server in an offline manner (#378), see also:

https://github.com/jazzband/pip-tools/issues/1220