### PR TITLE
fix return type annotation of `update_connection`

### DIFF
--- a/linien-server/linien_server/influxdb.py
+++ b/linien-server/linien_server/influxdb.py
@@ -45,7 +45,7 @@ class InfluxDBLogger:
         self._credentials = value
         save_credentials(value)
 
-    def update_connection(self) -> InfluxDBClient:
+    def update_connection(self) -> None:
         client = InfluxDBClient(
             url=self.credentials.url,
             token=self.credentials.token,


### PR DESCRIPTION
`update_connection` is annotated as returning an `InfluxDBClient` but doesn't actually return anything, which makes mypy fail. Changed the annotation to `None` to match what the method really does.